### PR TITLE
Fix ambiguous call to clamp.

### DIFF
--- a/src/trSEQ.cpp
+++ b/src/trSEQ.cpp
@@ -156,10 +156,10 @@ void trSEQ::step() {
 
 	if (nextStep) {
 		// Advance step
-		int numSteps = clamp(round(params[STEPS_PARAM].value + inputs[STEPS_INPUT].value), 1, 16);
+		int numSteps = clamp(static_cast<int>(round(params[STEPS_PARAM].value + inputs[STEPS_INPUT].value)), 1, 16);
 
 		index += 1;
-	
+
 		if (index >= numSteps) {
 			index = 0;
 		}
@@ -245,7 +245,7 @@ trSEQWidget::trSEQWidget(trSEQ *module) : ModuleWidget(module) {
 	addChild(ModuleLightWidget::create<MediumLight<BlueLight>>(Vec(103.4, 64.4), module, trSEQ::RESET_LIGHT));
 	addParam(ParamWidget::create<RoundSmallBlackSnapKnob>(Vec(132, 56), module, trSEQ::STEPS_PARAM, 1.0f, 16.0f, 16.0f));
 	addChild(ModuleLightWidget::create<MediumLight<BlueLight>>(Vec(289.4, 64.4), module, trSEQ::GATES_LIGHT));
-	
+
 	static const float portX[8] = {20, 58, 96, 135, 173, 212, 250, 289};
 
 


### PR DESCRIPTION
Compilation failed against Rack `v0.6` on Windows due to an ambiguous call to `clamp`.