### PR TITLE
fix: out of bound error in string when preview module

### DIFF
--- a/src/FUNKTION.cpp
+++ b/src/FUNKTION.cpp
@@ -122,9 +122,8 @@ struct FUNKTIONDisplay : TransparentWidget {
 	void drawLayer(const DrawArgs &args, int layer) override {
 if (layer ==1) {
 shared_ptr<Font> font = APP->window->loadFont(asset::plugin(pluginInstance, "res/LEDCalculator.ttf"));
-std::string fD= module ? module->fctDesc : "sin";
-		std::string to_display = "";
-		for (int i=0; i<14; i++) to_display = to_display + fD[i];
+std::string to_display= module ? module->fctDesc : "sin";
+		to_display.resize(14);
 		nvgFontSize(args.vg, 24);
 		nvgFontFaceId(args.vg, font->handle);
 		nvgTextLetterSpacing(args.vg, 0);

--- a/src/LABEL.cpp
+++ b/src/LABEL.cpp
@@ -21,7 +21,7 @@ struct LABEL : Module {
 	};
 	
 
-		std::string fileDesc = "Right clic to write";
+		std::string fileDesc = "Right click to write";
 	
 
 
@@ -71,9 +71,8 @@ struct LABELDisplay : TransparentWidget {
 	void drawLayer(const DrawArgs &args, int layer) override {
 if (layer ==1) {
 shared_ptr<Font> font = APP->window->loadFont(asset::plugin(pluginInstance, "res/LEDCalculator.ttf"));
-std::string fD= module ? module->fileDesc : "Right clic to write";
-		std::string to_display = "";
-		for (int i=0; i<20; i++) to_display = to_display + fD[i];
+std::string to_display= module ? module->fileDesc : "Right click to write";
+		to_display.resize(20);
 		nvgFontSize(args.vg, 24);
 		nvgFontFaceId(args.vg, font->handle);
 		nvgTextLetterSpacing(args.vg, 0);

--- a/src/PLAY.cpp
+++ b/src/PLAY.cpp
@@ -249,9 +249,8 @@ struct PLAYDisplay : TransparentWidget {
 	void drawLayer(const DrawArgs &args, int layer) override {
 if (layer ==1) {
 shared_ptr<Font> font = APP->window->loadFont(asset::plugin(pluginInstance, "res/LEDCalculator.ttf"));
-std::string fD= module ? module->fileDesc : "load sample";
-		std::string to_display = "";
-		for (int i=0; i<14; i++) to_display = to_display + fD[i];
+std::string to_display= module ? module->fileDesc : "load sample";
+		to_display.resize(14);
 		nvgFontSize(args.vg, 24);
 		nvgFontFaceId(args.vg, font->handle);
 		nvgTextLetterSpacing(args.vg, 0);


### PR DESCRIPTION
FUNKTION, LABEL, PLAY have a string out of bound error which does not always manifest itself.
using gcc-11 on archlinux reliably reproduces the crash.
this patch fixes it

see related discussion at https://github.com/DISTRHO/Cardinal/issues/92

